### PR TITLE
Ajustes Carga y seguridad

### DIFF
--- a/src/app/helpers/gestor_documental/firmaElectronicaHelper.ts
+++ b/src/app/helpers/gestor_documental/firmaElectronicaHelper.ts
@@ -34,7 +34,7 @@ export class FirmaElectronicaService {
         urlFileUp,
       },
     ];
-    return this.rqManager.post('firma_electronica/verify', payload);
+    return this.rqManager.post('verify', payload);
   }
 
 }

--- a/src/app/managers/popUpManager.ts
+++ b/src/app/managers/popUpManager.ts
@@ -41,4 +41,25 @@ export class PopUpManager {
         return this.showAlert('warning', text,
             this.translate.instant('Atención'));
     }
+
+    public showSignAlert (text) {
+        let translatedText = '';
+        let errorTipo = 'warning';
+        let operacionTipo = 'Atención';
+        switch(text){
+            case 1:
+                translatedText = this.translate.instant('GLOBAL.firmaInvalida');
+                break;
+            case 2:
+                translatedText = this.translate.instant('GLOBAL.docsComp');
+                break;
+            case 3:
+                translatedText = this.translate.instant('GLOBAL.firmaVerificada');
+                errorTipo = 'success';
+                operacionTipo = 'GLOBAL.operacion_exitosa'
+                break;
+        }
+        return this.showAlert(errorTipo, translatedText,
+            this.translate.instant(operacionTipo));
+    }
 }

--- a/src/app/managers/popUpManager.ts
+++ b/src/app/managers/popUpManager.ts
@@ -46,7 +46,7 @@ export class PopUpManager {
         let translatedText = '';
         let errorTipo = 'warning';
         let operacionTipo = 'Atención';
-        switch(text){
+        switch (text) {
             case 1:
                 translatedText = this.translate.instant('GLOBAL.firmaInvalida');
                 break;
@@ -56,7 +56,7 @@ export class PopUpManager {
             case 3:
                 translatedText = this.translate.instant('GLOBAL.firmaVerificada');
                 errorTipo = 'success';
-                operacionTipo = 'GLOBAL.operacion_exitosa'
+                operacionTipo = 'GLOBAL.operacion_exitosa';
                 break;
         }
         return this.showAlert(errorTipo, translatedText,

--- a/src/app/pages/verificar/verificar.component.ts
+++ b/src/app/pages/verificar/verificar.component.ts
@@ -72,6 +72,7 @@ export class VerificarComponent implements OnInit {
   // fin captura documento
   public checkFirma() {
     if (!this.firmaId || this.firmaId.length !== 36) {
+      this.popUpMan.showCautionAlert('Debe ingresar una firma válida');
       return;
     }
     if (this.base64Output == null) {

--- a/src/app/pages/verificar/verificar.component.ts
+++ b/src/app/pages/verificar/verificar.component.ts
@@ -72,7 +72,7 @@ export class VerificarComponent implements OnInit {
   // fin captura documento
   public checkFirma() {
     if (!this.firmaId || this.firmaId.length !== 36) {
-      this.popUpMan.showCautionAlert('Debe ingresar una firma válida');
+      this.popUpMan.showSignAlert(1);
       return;
     }
     if (this.base64Output == null) {
@@ -102,9 +102,9 @@ export class VerificarComponent implements OnInit {
         }
         Swal.close();
         if (!this.fileEqual) {
-          this.popUpMan.showCautionAlert('Los documentos no coinciden');
+          this.popUpMan.showSignAlert(2);
         } else {
-          this.popUpMan.showSuccessAlert('Se ha verificado correctamente la firma con el documento');
+          this.popUpMan.showSignAlert(3);
         }
       });
   }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -46,6 +46,9 @@
   },
   "GLOBAL": {
     "verificarFirma": "Verificar Firma",
+    "firmaInvalida": "Debe ingresar una firma válida",
+    "firmaVerificada": "Se ha verificado correctamente la firma con el documento",
+    "docsComp": "Los documentos no coinciden",
     "volver": "Volver",
     "Errores": {
       "ErrorTercero": "Ingrese un tercero válido",


### PR DESCRIPTION
Se arregla error 500 al enviar una firma vacía por peticion y se muestra pop up cuando la firma no se ingresa o no es del rango valido, además se corrige el endpoint a firma electronica mid

Esto corresponde a los issues udistrital/core_documentacion#78 y udistrital/core_documentacion#79